### PR TITLE
为报复没有眼光的苹果用户，不支持macOS以使它们无法使用世界上最好的启动器。我来助您一臂之力！

### DIFF
--- a/Carbon-Launcher/macos.c
+++ b/Carbon-Launcher/macos.c
@@ -1,7 +1,0 @@
-#include <stdlib.h>
-
-int main()
-{
-    system("java -Xmx100M -Xms100M -jar ./Carbon.jar");
-    return 0;
-}

--- a/build.sh
+++ b/build.sh
@@ -8,19 +8,16 @@ function makeDirectory(){
 makeDirectory ./exec
 makeDirectory ./exec/tmp
 makeDirectory ./exec/Linux
-makeDirectory ./exec/MacOS
 makeDirectory ./exec/Windows
 makeDirectory ./exec/tmp/Carbon-Linux-x86_64
 makeDirectory ./exec/tmp/Carbon-Linux-i386
 makeDirectory ./exec/tmp/Carbon-Windows-x86_64
 makeDirectory ./exec/tmp/Carbon-Windows-i386
-makeDirectory ./exec/tmp/Carbon-MacOS-x86_64
 ./gradlew shadowJar
 cp ./build/libs/Carbon.jar ./exec/tmp/Carbon-Linux-x86_64
 cp ./build/libs/Carbon.jar ./exec/tmp/Carbon-Linux-i386
 cp ./build/libs/Carbon.jar ./exec/tmp/Carbon-Windows-x86_64
 cp ./build/libs/Carbon.jar ./exec/tmp/Carbon-Windows-i386
-cp ./build/libs/Carbon.jar ./exec/tmp/Carbon-MacOS-x86_64
 gcc ./Carbon-Launcher/linux.c -O3 -o ./exec/tmp/Carbon-Linux-x86_64/Carbon-Linux-x86_64
 gcc ./Carbon-Launcher/linux.c -m32 -O3 -o ./exec/tmp/Carbon-Linux-i386/Carbon-Linux-i386
 x86_64-w64-mingw32-windres -i ./Carbon-Launcher/img.rc --input-format=rc -o ./exec/tmp/img64.res -O coff
@@ -29,11 +26,9 @@ x86_64-w64-mingw32-gcc ./Carbon-Launcher/windows.c -c -O3 -o ./exec/tmp/Carbon-W
 i686-w64-mingw32-gcc ./Carbon-Launcher/windows.c -c -O3 -o ./exec/tmp/Carbon-Windows-i386.o
 x86_64-w64-mingw32-gcc ./exec/tmp/Carbon-Windows-x86_64.o ./exec/tmp/img64.res -o ./exec/tmp/Carbon-Windows-x86_64/Carbon-Windows-x86_64.exe
 i686-w64-mingw32-gcc ./exec/tmp/Carbon-Windows-i386.o ./exec/tmp/img32.res -o ./exec/tmp/Carbon-Windows-i386/Carbon-Windows-i386.exe
-x86_64-apple-darwin14-clang ./Carbon-Launcher/macos.c -o ./exec/tmp/Carbon-MacOS-x86_64/Carbon-MacOS-x86_64
 cd ./exec/tmp
 tar -zcvf ../Linux/Carbon-Linux-x86_64.tar.gz ./Carbon-Linux-x86_64
 tar -zcvf ../Linux/Carbon-Linux-i386.tar.gz ./Carbon-Linux-i386
-tar -zcvf ../MacOS/Carbon-MacOS-x86_64.tar.gz ./Carbon-MacOS-x86_64
 zip -r -q -o ../Windows/Carbon-Windows-x86_64.zip ./Carbon-Windows-x86_64
 zip -r -q -o ../Windows/Carbon-Windows-i386.zip ./Carbon-Windows-i386
 cd ../


### PR DESCRIPTION
移除了对 macOS 的所有支持。虽然 Java Swing 可以支持 macOS 但我们选择不支持。因为原作者Frank痛恨苹果用户，为报复苹果用户，不支持macOS以使它们无法使用世界上最好的启动器，只能使用更加垃圾与震惊🤯的启动器 [Epherome](https://github.com/ResetPower/Epherome) 来代替。

Removed all supports for macOS. Although Java Swing is able to support macOS, we've chosen not to support it. Because the author Frank hates Apple and macOS and its users. Don't support macOS make them not able to use the best launcher in the world. So if you are using macOS and want to try Carbon, try  [Epherome](https://github.com/ResetPower/Epherome) alternative.